### PR TITLE
JCN-94-environment-builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+- When fails building throw an exit code.
+
 ## [1.1.1] - 2019-07-16
 ### Added
 - `index` fix for npx excecution

--- a/lib/environment-builder.js
+++ b/lib/environment-builder.js
@@ -69,13 +69,13 @@ class EnvironmentBuilder {
 			// Checks if path exist
 			if(!(await this.exists(this.constructor.envDir)) || !(await this.exists(environmentDir))) {
 				logger(`Directory: '${environmentDir}' doesn't exist.`, 'ERROR', true);
-				return;
+				return process.exit(-1);
 			}
 
 			// checks if source folde is empty
 			if(await this.isEmptyFolder(environmentDir)) {
 				logger(`Directory: '${environmentDir}' is empty.`, 'ERROR', true);
-				return;
+				return process.exit(-1);
 			}
 
 			logger(`Environment '${environment}' directory found.`);
@@ -96,6 +96,7 @@ class EnvironmentBuilder {
 			logger(`Environment '${environment}' created.\n`, 'SUCCESS');
 		} catch(error) {
 			logger(`${error.message}.`, 'ERROR', true);
+			return process.exit(-1);
 		}
 
 	}

--- a/tests/environment-builder-test.js
+++ b/tests/environment-builder-test.js
@@ -12,18 +12,6 @@ const sandbox = require('sinon').createSandbox();
 
 const { EnvironmentBuilder } = require('./../lib');
 
-before(() => {
-	// Avoid showing messages in console during tests
-	sandbox.stub(console, 'log').callsFake(() => true);
-	sandbox.stub(console, 'error').callsFake(() => true);
-	sandbox.stub(process, 'exit');
-});
-
-after(() => {
-	sandbox.restore();
-});
-
-
 describe('Exists', () => {
 	let envBuilder;
 	let directory;
@@ -107,18 +95,29 @@ describe('EnvironmentBuilder', () => {
 	context('when some environments folders not exists or are empties', () => {
 
 		let envBuilder;
+		let exit;
 
 		beforeEach(() => {
+			// Avoid showing messages in console during tests
+			sandbox.stub(console, 'log').callsFake(() => true);
+			sandbox.stub(console, 'error').callsFake(() => true);
+			exit = sandbox.stub(process, 'exit');
+
 			envBuilder = new EnvironmentBuilder();
 		});
 
 		afterEach(() => {
 			MockFs.restore();
+			sandbox.restore();
 		});
 
 		it('should not create config folder if \'root/environments\' not exist', async () => {
 
 			await envBuilder.execute();
+
+			sandbox.assert.calledOnce(exit);
+			sandbox.assert.calledWith(exit, -1);
+
 			assert(!(await envBuilder.exists(EnvironmentBuilder.configDir)));
 
 		});
@@ -129,7 +128,12 @@ describe('EnvironmentBuilder', () => {
 			});
 
 			await envBuilder.execute();
+
+			sandbox.assert.calledOnce(exit);
+			sandbox.assert.calledWith(exit, -1);
+
 			assert(!(await envBuilder.exists(EnvironmentBuilder.configDir)));
+
 		});
 
 		it('should not create config folder if \'root/environments/[ENVIRONMENT]\' not exist', async () => {
@@ -142,7 +146,12 @@ describe('EnvironmentBuilder', () => {
 			});
 
 			await envBuilder.execute('sac');
+
+			sandbox.assert.calledOnce(exit);
+			sandbox.assert.calledWith(exit, -1);
+
 			assert(!(await envBuilder.exists(EnvironmentBuilder.configDir)));
+
 		});
 
 		it('should not create config folder if \'root/environments/[ENVIRONMENT]\' is empty', async () => {
@@ -153,19 +162,31 @@ describe('EnvironmentBuilder', () => {
 			});
 
 			await envBuilder.execute();
+
+			sandbox.assert.calledOnce(exit);
+			sandbox.assert.calledWith(exit, -1);
+
 			assert(!(await envBuilder.exists(EnvironmentBuilder.configDir)));
+
 		});
 	});
 
 	context('when environments folders exists, config folder not', () => {
 		let envBuilder;
+		let exit;
 
 		beforeEach(() => {
+			// Avoid showing messages in console during tests
+			sandbox.stub(console, 'log').callsFake(() => true);
+			sandbox.stub(console, 'error').callsFake(() => true);
+			exit = sandbox.stub(process, 'exit');
+
 			envBuilder = new EnvironmentBuilder();
 		});
 
 		afterEach(() => {
 			MockFs.restore();
+			sandbox.restore();
 		});
 
 		it('should not replace config folder if can\'t copy files', async () => {
@@ -184,6 +205,9 @@ describe('EnvironmentBuilder', () => {
 			assert(!(await envBuilder.exists(EnvironmentBuilder.configDir)));
 
 			await envBuilder.execute();
+
+			sandbox.assert.calledOnce(exit);
+			sandbox.assert.calledWith(exit, -1);
 
 			// Config doesn't exist after
 			assert(!(await envBuilder.exists(EnvironmentBuilder.configDir)));
@@ -347,11 +371,16 @@ describe('EnvironmentBuilder', () => {
 			let envBuilder;
 
 			beforeEach(() => {
+				// Avoid showing messages in console during tests
+				sandbox.stub(console, 'log').callsFake(() => true);
+				sandbox.stub(console, 'error').callsFake(() => true);
+
 				envBuilder = new EnvironmentBuilder();
 			});
 
 			afterEach(() => {
 				MockFs.restore();
+				sandbox.restore();
 			});
 
 			it('should replace config folder with \'local\' (no params passed) environment, only files', async () => {
@@ -517,13 +546,20 @@ describe('EnvironmentBuilder', () => {
 
 		describe('config folder is not empty', () => {
 			let envBuilder;
+			let exit;
 
 			beforeEach(() => {
+				// Avoid showing messages in console during tests
+				sandbox.stub(console, 'log').callsFake(() => true);
+				sandbox.stub(console, 'error').callsFake(() => true);
+				exit = sandbox.stub(process, 'exit');
+
 				envBuilder = new EnvironmentBuilder();
 			});
 
 			afterEach(() => {
 				MockFs.restore();
+				sandbox.restore();
 			});
 
 			it('should not replace config folder content if can\'t delete files in config', async () => {
@@ -559,6 +595,9 @@ describe('EnvironmentBuilder', () => {
 
 				// try to build 'local' environment
 				await envBuilder.execute();
+
+				sandbox.assert.calledOnce(exit);
+				sandbox.assert.calledWith(exit, -1);
 
 				// Config exists after and it's not empty
 				assert(await envBuilder.exists(EnvironmentBuilder.configDir));
@@ -672,6 +711,10 @@ describe('EnvironmentBuilder', () => {
 		let envBuilder;
 
 		beforeEach(() => {
+
+			sandbox.stub(console, 'log').callsFake(() => true);
+			sandbox.stub(console, 'error').callsFake(() => true);
+
 			envBuilder = new EnvironmentBuilder();
 
 			MockFs({
@@ -690,6 +733,7 @@ describe('EnvironmentBuilder', () => {
 
 		afterEach(() => {
 			MockFs.restore();
+			sandbox.restore();
 		});
 
 		it('should build default environment', async () => {

--- a/tests/environment-builder-test.js
+++ b/tests/environment-builder-test.js
@@ -16,6 +16,7 @@ before(() => {
 	// Avoid showing messages in console during tests
 	sandbox.stub(console, 'log').callsFake(() => true);
 	sandbox.stub(console, 'error').callsFake(() => true);
+	sandbox.stub(process, 'exit');
 });
 
 after(() => {


### PR DESCRIPTION
**PAQUETE ENVIRONMENT-BUILDER**
JCN-94 Paquete npm environment-builder

**LINK AL TICKET**
https://fizzmod.atlassian.net/browse/JCN-94

**DESCRIPCIÓN DEL REQUERIMIENTO**
Se solicita agregar código de error de salida al fallar el building

**DESCRIPCIÓN DE LA SOLUCIÓN**
Se agrego el `process.exit(-1)` cuando falla el building.
Se corrigieron los unit test.